### PR TITLE
Fix to prevent main.js from being cached by the browser.

### DIFF
--- a/modules/login/src/main/java/edu/mit/ll/nics/session/SessionFilter.java
+++ b/modules/login/src/main/java/edu/mit/ll/nics/session/SessionFilter.java
@@ -56,6 +56,7 @@ public class SessionFilter implements Filter {
 	private static String FORGOTPASSWORD_PAGE = "/nics/forgotpassword";
 	private static String REINIT_PARAM = "reinit";
 	private static String HOME_PAGE = "home.html";
+	private static String MAINAPP_JS = "main.js";
 	private static String USERNAME = "username";
 	private static String SESSION_ID = "sessionId";
 	
@@ -80,8 +81,9 @@ public class SessionFilter implements Filter {
 		String atmosphereTransport = req.getParameter("X-Atmosphere-Transport");
 		
 		//Do not cache the home page to allow the filter to redirect if the user 
-		//is not validated
-		if(requestURI.endsWith(HOME_PAGE)){
+		//is not validated.
+		//Also do not cache the main app js to allow cache busting to work.
+		if(requestURI.endsWith(HOME_PAGE) || requestURI.endsWith(MAINAPP_JS)){
 			resp.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0");
 	        resp.setHeader("Pragma", "no-cache");
 		}

--- a/webapp/src/main/webapp/home.html
+++ b/webapp/src/main/webapp/home.html
@@ -71,7 +71,7 @@
 		<link rel="stylesheet" type="text/css" href="styles/print/print.css" />
 		<link rel="stylesheet" type="text/css" href="styles/report/report.css" />
 
-		<script data-main="js/main.js" src="js/lib/require.js"></script>
+		<script data-main="js/main.js?v=2.6.1" src="js/lib/require.js"></script>
 	</head>
 	<body></body>
 </html>


### PR DESCRIPTION
Cache busting fix in requirejs was thwarted by browser caching of the main.js, where requirejs is initialized. Includes 2 fixes for the upcoming release:

1 - Modded the servlet request filter to add no-cache directives for main.js.
2 - Added a cache busting query param to the main.js script reference in home.html. This is needed since the client won't even ask the server about main.js (or receive the new no-cache directive) since it is already cached with no expiration.