### PR TITLE
WFS parameter fix and cache bust.

### DIFF
--- a/modules/datalayer/src/main/js/nics/modules/datalayer/DatalayerBuilder.js
+++ b/modules/datalayer/src/main/js/nics/modules/datalayer/DatalayerBuilder.js
@@ -94,7 +94,7 @@ define(['iweb/CoreModule', 'ol', './TokenManager', './ArcGISFeatureRequestManage
 						  "&srsname=EPSG:3857&bbox={4}{5}",
 					  window.location.protocol,
 					  window.location.host,
-					  url, layername, extent.join(','), '&EPSG:3857');
+					  url, layername, extent.join(','), ',EPSG:3857');
 				  
 					if(config.secure){
 						var token = TokenManager.getToken(config.datasourceid);

--- a/webapp/src/main/webapp/home.html
+++ b/webapp/src/main/webapp/home.html
@@ -71,7 +71,7 @@
 		<link rel="stylesheet" type="text/css" href="styles/print/print.css" />
 		<link rel="stylesheet" type="text/css" href="styles/report/report.css" />
 
-		<script data-main="js/main.js?v=2.6.1" src="js/lib/require.js"></script>
+		<script data-main="js/main.js?v=2017.1.3" src="js/lib/require.js"></script>
 	</head>
 	<body></body>
 </html>

--- a/webapp/src/main/webapp/js/main.js
+++ b/webapp/src/main/webapp/js/main.js
@@ -28,7 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 require.config({
-    urlArgs: "v=v6.2.1a"
+    urlArgs: "v=2017.1.3"
 });
 require([
     "iweb/CoreModule", "iweb/modules/MapModule",


### PR DESCRIPTION
Reverted part of the oes-148 (originally committed under oes-52 branch) code change to fix WFS AVL calls.

Reverted &EPSG:3857 back to be the fifth bbox argument per WFS spec: https://portal.opengeospatial.org/files/?artifact_id=8339
Bumped cache busting version string since this is a javascript fix.