### PR TITLE
Changing ArcGisRest tab name and panel title to ArcGIS MapServer. 

### DIFF
--- a/modules/datalayer/src/main/js/nics/modules/datalayer/DataWindowController.js
+++ b/modules/datalayer/src/main/js/nics/modules/datalayer/DataWindowController.js
@@ -88,7 +88,7 @@ define(['ext', 'iweb/CoreModule', 'nics/modules/UserProfileModule',
 						workspaceId: this.workspaceId
 					}),
 					new DatasourceImportPanel({
-						title: 'ArcGISRest',
+						title: 'ArcGIS MapServer',
 						dataSourceType: 'arcgisrest',
 						capabilitiesFormat: new ArcGISCapabilities(),
 						workspaceId: this.workspaceId


### PR DESCRIPTION
Requested to be more specific since ArcGIS FeatureServer isn't supported as a data source yet and it was causing confusion. Dropped the 'rest' in the name since it took up too much screen real estate and is implied by 'MapServer' anyways.