### PR TITLE
Fixes an issue with secured arcgis wfs passwords where special chars …

### DIFF
--- a/modules/datalayer/src/main/js/nics/modules/datalayer/DatasourceImportController.js
+++ b/modules/datalayer/src/main/js/nics/modules/datalayer/DatasourceImportController.js
@@ -195,7 +195,7 @@ define(['ext', 'ol', "iweb/CoreModule", "nics/modules/UserProfileModule", "./Tok
 							   		"username={3}&password={4}",
 									endpoint,
 									UserProfile.getWorkspaceId(),
-									internalurl, username, password);
+									internalurl, username, encodeURIComponent(password));
 								
 								var topic = Core.Util.generateUUID();
 								Core.EventManager.createCallbackHandler(topic, _this, _this.handleTokenResponse, 


### PR DESCRIPTION
…in the password aren't being url encoded properly when forming the token generator GET request. The result was typically a username/password validation error back to the client.

Accompanied by am em-api fix  to encode the password before calling the arcgis token generator.