### PR TITLE
Setting the user-agent to empty was causing certain CDN's (akamai) to…

### DIFF
--- a/modules/datalayer/src/main/java/edu/mit/ll/nics/servlet/WFSProxyServlet.java
+++ b/modules/datalayer/src/main/java/edu/mit/ll/nics/servlet/WFSProxyServlet.java
@@ -69,7 +69,7 @@ public class WFSProxyServlet extends HttpServlet implements Servlet {
 			String token = (String) SessionHolder.getData(request.getSession().getId(), SessionHolder.TOKEN);
 			headerOptions.put("Cookie", String.format("AMAuthCookie=%1$s;iPlanetDirectoryPro=%1$s", token));
 		}
-		headerOptions.put("User-Agent", "");
+		headerOptions.put("User-Agent", "NicsWeb");
         
         BasicRequest basicRequest = new BasicRequest();
         String result = (String) basicRequest.getRequest(url, headerOptions);


### PR DESCRIPTION
… refuse the request. While not explicitly setting the UA causes java to insert "Java/<version>" in the header, which is often blocked by websites to combat bots. I set it to something benign (NicsWeb).