### PR TITLE
Fixed GeoLocation issue when existing incident is selected

### DIFF
--- a/modules/incident/src/main/js/nics/modules/incident/IncidentController.js
+++ b/modules/incident/src/main/js/nics/modules/incident/IncidentController.js
@@ -151,12 +151,24 @@ define(['iweb/CoreModule',
 				this.model.setCurrentIncident(incident);
 				this.getView().setIncidentLabel(menuItem.text, menuItem.incidentId);
 				
-				var latAndLonValues = [menuItem.lon,menuItem.lat];
-    			var center = ol.proj.transform(latAndLonValues,'EPSG:4326','EPSG:3857');
-    			MapModule.getMap().getView().setCenter(center);
-				
+                var latAndLonValues = [menuItem.lon,menuItem.lat];
+                var center = ol.proj.transform(latAndLonValues,'EPSG:4326','EPSG:3857');
+                var view = MapModule.getMap().getView();
+
+                this.mixins.geoApp.removeLayer();
+                view.setCenter(center);
+                var point = this.buildPoint(menuItem.lat, menuItem.lon, view);
+                var feature = this.mixins.geoApp.buildFeature(point,"");
+                this.mixins.geoApp.getLayer().getSource().addFeature(feature);
+                MapModule.getMapController().zoomTo(15);
+
 				Core.EventManager.fireEvent("nics.incident.join", incident);
 			},
+
+			buildPoint: function(lat, long, view) {
+                return new ol.geom.Point([long, lat])
+                    .transform(ol.proj.get('EPSG:4326'), view.getProjection());
+            },
 			
 			onJoinArchivedIncident: function(evt, incident){
 				this.onMIVJoinIncident(evt, incident.name);


### PR DESCRIPTION
When previous/existing incident is selected from the Incidents drop down, the map doesn't put a pin on the map and the map doesn't move to the location.